### PR TITLE
add dots that imply a currency is expanded

### DIFF
--- a/src/Components/LandingCurrency/LandingCurrency.css
+++ b/src/Components/LandingCurrency/LandingCurrency.css
@@ -69,13 +69,14 @@
   text-align: center;
 }
 
+.expansion-dots-glowing,
 .expansion-dots {
-  height: 70px;
-  justify-content: center;
+  height: 100%;
   cursor: pointer;
 }
 
-.expansion-dots div {
+.expansion-dots div,
+.expansion-dots-glowing div {
   height: 5px;
   width: 5px;
   margin: 2px 0px 2px 10px;
@@ -84,23 +85,24 @@
   background-color: rgba(109, 109, 109, 0.514);
 }
 
+.expansion-dots-glowing div:first-child,
 .expansion-dots div:first-child {
-  margin-top: 1.5rem;
+  margin-top: 2rem;
 }
 
-.expansion-dots:hover div {
+.expansion-dots-glowing div {
   animation: wavey 2s linear infinite;
 }
 
-.expansion-dots div:first-child {
+.expansion-dots-glowing div:first-child {
   animation-delay: 0.3s;
 }
 
-.expansion-dots div:nth-child(2) {
+.expansion-dots-glowing div:nth-child(2) {
   animation-delay: 0.5s;
 }
 
-.expansion-dots div:nth-child(3) {
+.expansion-dots-glowing div:nth-child(3) {
   animation-delay: 0.7s;
 }
 

--- a/src/Components/LandingCurrency/LandingCurrency.js
+++ b/src/Components/LandingCurrency/LandingCurrency.js
@@ -23,6 +23,7 @@ class LandingCurrency extends Component {
 
   render() {
     const { symbol, name, price, percent_change, rank } = this.props.currency;
+    const { expanded } = this.state;
     return (
       <div className="currency-card">
         <div className="card-inside-text">
@@ -39,7 +40,10 @@ class LandingCurrency extends Component {
           <div className="cc-right">
             <p>{percent_change}</p>
           </div>
-          <div className="expansion-dots" onClick={this.expand}>
+          <div
+            className={expanded ? "expansion-dots-glowing" : "expansion-dots"}
+            onClick={this.expand}
+          >
             <div />
             <div />
             <div />


### PR DESCRIPTION
- [_] Wrote Tests
- [✅] Implemented
- [_] Reviewed
 
# Necessary checkmarks:

- [_] All Tests are Passing

- [✅] The code will run locally

## Type of change

- [✅] New feature
- [_] Bug Fix

# Description:
now what a user clicks on the dots on the side of a card, they expand the card. there's also an animation that plays when it's active.


# Implements:

# Fixes

# Check the correct boxes

- [_]This broke nothing
- [_] This broke some stuff
- [_] This broke everything

# Testing Changes

- [_] No Tests have been changed
- [_] Some Tests have been changed
- [_] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [_] My code has no commented out code (explanatory comments are fine)
- [_] I have reviewed my code
- [_] I have commented my code, particularly in hard-to-understand areas
- [_] I have fully tested my code

# Please Include a link to a gif of your feelings about this branch
