### PR TITLE
Add line chart to landing currency

### DIFF
--- a/src/Components/LandingCurrency/LandingCurrency.css
+++ b/src/Components/LandingCurrency/LandingCurrency.css
@@ -29,12 +29,11 @@
 }
 
 .expanded-graph {
-  padding: 0.5rem 0;
   transition: 0.2s;
 }
 
 .plot-container.plotly {
-  transform: scale(0.9);
+  transform: scale(0.8);
   padding: 0%;
 }
 

--- a/src/Components/LandingCurrency/LandingCurrency.css
+++ b/src/Components/LandingCurrency/LandingCurrency.css
@@ -28,6 +28,16 @@
   text-transform: uppercase;
 }
 
+.expanded-graph {
+  padding: 0.5rem 0;
+  transition: 0.2s;
+}
+
+.plot-container.plotly {
+  transform: scale(0.9);
+  padding: 0%;
+}
+
 .cc-left img {
   width: 20px;
   height: 20px;

--- a/src/Components/LandingCurrency/LandingCurrency.css
+++ b/src/Components/LandingCurrency/LandingCurrency.css
@@ -34,7 +34,6 @@
 
 .plot-container.plotly {
   transform: scale(0.8);
-  padding: 0%;
 }
 
 .cc-left img {

--- a/src/Components/LandingCurrency/LandingCurrency.js
+++ b/src/Components/LandingCurrency/LandingCurrency.js
@@ -89,6 +89,10 @@ class LandingCurrency extends Component {
               onClick={this.handleClick}
               alt=""
             />
+          </div>
+        )}
+        {this.state.expanded && (
+          <div className="expanded-graph">
             <LineChart />
           </div>
         )}

--- a/src/Components/LandingCurrency/LandingCurrency.js
+++ b/src/Components/LandingCurrency/LandingCurrency.js
@@ -5,7 +5,7 @@ import HeartP from "../../Assets/heartpink.svg";
 import { Icons } from "../../Assets/cryptoIcons/cryptoIcons";
 import DataCleaner from "../../Utils/Cleaners/";
 import { sendFavorites } from "../../Utils/API/";
-
+import LineChart from "../LineChart/LineChart"
 class LandingCurrency extends Component {
   constructor(props) {
     super(props);
@@ -76,10 +76,10 @@ class LandingCurrency extends Component {
         </div>
         {this.state.expanded && (
           <div className="expanded-currency">
-            <button 
+            <button
               className="ec-right"
               onClick={this.handleClick}
-              name={name}> 
+              name={name}>
               View
             </button>
             <img
@@ -89,6 +89,7 @@ class LandingCurrency extends Component {
               onClick={this.handleClick}
               alt=""
             />
+            <LineChart />
           </div>
         )}
       </div>

--- a/src/Components/LineChart/LineChart.js
+++ b/src/Components/LineChart/LineChart.js
@@ -40,16 +40,26 @@ class LineChart extends Component {
         ]} style={{width: '100%', height: '100%'}}
           layout={
           {
-            width: 400,
-            height: 400,
-            // autosize: true,
+            margin: {
+              l: 60,
+              r: 40,
+              b: 20,
+              t: 25,
+              pad: 5
+            },
+            width: 350,
+            height: 330,
             title: 'Price History',
             font: {color: 'white'},
             visible: false,
-            xaxis: {title: 'Time',
+            xaxis: {title: false,
                     showgrid: false},
-            yaxis: {title:'Price',
+            yaxis: {title:'Price $',
+                    titlefont: {
+                    size: 16,
+                    },
                     showgrid: false},
+
                     paper_bgcolor: 'rgba(0,0,0,0)',
                     plot_bgcolor: 'rgba(0,0,0,0)',
           }

--- a/src/Components/LineChart/LineChart.js
+++ b/src/Components/LineChart/LineChart.js
@@ -21,22 +21,28 @@ class LineChart extends Component {
       x_values.push(data.date)
       y_values.push(data.price)
     });
-
+    const modeBarConfig = {displayModeBar: false}
     return ([
+      <div
+        style={{
+          width: this.state.fullWidth ? '100%' : '100%',
+        }}>
       <section>
-        <Plot data={[
+        <Plot config={modeBarConfig} data={[
           {
             x: x_values,
             y: y_values,
             type: 'linear',
             mode: 'lines',
-            marker: {color: 'green'},
+            marker: {color: '#794dff'},
             fill: 'tozeroy',
           }
-        ]} layout={
+        ]} style={{width: '100%', height: '100%'}}
+          layout={
           {
-            width: 320,
-            height: 240,
+            width: 400,
+            height: 400,
+            // autosize: true,
             title: 'Price History',
             font: {color: 'white'},
             visible: false,
@@ -50,6 +56,7 @@ class LineChart extends Component {
         }
         />
       </section>
+      </div>
     ])
   }
 }

--- a/src/Components/LineChart/LineChart.js
+++ b/src/Components/LineChart/LineChart.js
@@ -47,7 +47,6 @@ class LineChart extends Component {
               t: 25,
               pad: 5
             },
-            width: 350,
             height: 330,
             title: 'Price History',
             font: {color: 'white'},

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -10,3 +10,5 @@ window.matchMedia = window.matchMedia || function() {
     removeListener: function() {}
   };
 };
+
+window.URL.createObjectURL = function() {};


### PR DESCRIPTION
# closes #73 

- [ ] Wrote Tests
- [X] Implemented
- [X] Reviewed

# Necessary checkmarks:

- [ ] All Tests are Passing - not all, but more are passing now

- [X] The code will run locally

## Type of change

- [X] New feature
- [X] Resolve test errors

# Description:
# New feature:
Adds a Plotly line chart to the LandingCurrency component that is displayed when it is expanded. This line chart displays price over time for a Bitcoin, but the next goal would be to make this dynamic for whatever coin. I or someone else can work on that on a separate branch. 

# Resolve test errors: 
I followed advice [here](https://github.com/plotly/react-plotly.js/issues/115) to resolve the error I saw when I ran the Jest test suite: window.URL.createObjectURL is not a function. To fix it, I added `window.URL.createObjectURL = function() {};` to `src/setupTests.js`.
 
# Check the correct boxes

- [X] This broke nothing
- [ ] This broke some stuff
- [ ] This broke everything

# Testing Changes

- [X] No Tests have been changed
- [ ] Tests have been added
- [ ] Some Tests have been changed
- [ ] All of the Tests have been changed(Please describe what in the world happened)

# Checklist:

- [X] My code has no commented out code (explanatory comments are fine)
- [X] I have reviewed my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have fully tested my code

# Progress pic: 
<img width="359" alt="screen shot 2019-01-18" src="https://user-images.githubusercontent.com/36902512/51429984-cc3a5300-1bd1-11e9-87ac-9275c05286cd.png">


# Please Include a link to a gif of your feelings about this branch
![](https://media.giphy.com/media/vMEjhlxsBR7Fe/giphy.gif)